### PR TITLE
Fix build for Inkscape 0.92+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,17 +20,17 @@ all: build
 	$(SASS) $<:$@
 
 src/img/icon-%.png: src/img/icon.svg
-	$(SVGRASTER) -w $* --export-png $@ $<
+	$(SVGRASTER) -w $* --export-filename $@ $<
 	$(PNGOPTIMIZE) $@
 
 package-icon.png: src/img/icon.svg
-	$(SVGRASTER) -w 96 --export-png nb-$@ $<
+	$(SVGRASTER) -w 96 --export-filename nb-$@ $<
 	convert nb-$@ -bordercolor transparent -border 16 $@
 	$(RM) nb-$@
 	$(PNGOPTIMIZE) $@
 
 src/img/icon-nope-%.png: src/img/icon-nope.svg
-	$(SVGRASTERDRAWING) -w $* --export-png $@ $<
+	$(SVGRASTERDRAWING) -w $* --export-filename $@ $<
 	$(PNGOPTIMIZE) $@
 
 build: $(OBJS) $(COPIED)


### PR DESCRIPTION
Hey, thanks for this extension!

I tried to build it but it looks like they changed the argument to export SVGs to PNG before Inkscape hit 1.0: https://wiki.inkscape.org/wiki/index.php?title=Using_the_Command_Line#Changes_from_0.92

Here's the patch that fixes it.